### PR TITLE
Update django 4

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - uses: actions/cache@v2
         with:
@@ -55,8 +55,8 @@ jobs:
 
   dependency-check:
     name: Dependency-Check
-    runs-on: ubuntu-18.04
-    container: centos/python-36-centos7
+    runs-on: ubuntu-latest
+    container: centos/python-38-centos7
     strategy:
       fail-fast: false
 
@@ -78,17 +78,17 @@ jobs:
 
   Inspection:
     name: Code Inspection
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - uses: actions/cache@v2
         with:

--- a/container/qp_mantid_python36.D
+++ b/container/qp_mantid_python36.D
@@ -9,7 +9,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-add-repository "deb [arch=amd64
   cp /opt/Mantid/bin/Mantid.properties /opt/Mantid/lib/Mantid.properties
 
 USER isisautoreduce
-RUN python3 -m pip install --user autoreduce_qp==22.0.0.dev23
+RUN python3 -m pip install --user autoreduce_qp==22.0.0.dev24
 USER root
 RUN python3 -m pip uninstall -y h5py && apt install --reinstall -y python3-h5py
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="autoreduce_qp",
-    version="22.0.0.dev23",  # when updating the version here make sure to also update qp_mantid_python36.D
+    version="22.0.0.dev24",  # when updating the version here make sure to also update qp_mantid_python36.D
     description="ISIS Autoreduction queue processor",
     author="ISIS Autoreduction Team",
     url="https://github.com/autoreduction/autoreduce/",

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ setup(
     author="ISIS Autoreduction Team",
     url="https://github.com/autoreduction/autoreduce/",
     install_requires=[
-        "autoreduce_db==22.0.0.dev21", "Django", "fire==0.4.0", "plotly==5.3.1", "kaleido==0.2.1", "stomp.py==7.0.0",
-        "docker==5.0.3"
+        "autoreduce_db==22.0.0.dev22", "Django>=3.2.10", "fire==0.4.0", "plotly==5.3.1", "kaleido==0.2.1",
+        "stomp.py==7.0.0", "docker==5.0.3"
     ],
     packages=find_packages(),
     entry_points={


### PR DESCRIPTION
### Summary of work
Update tests to Python 3.8 to allow for Django 4.x
Uses Django>=3.2.10 to allow use on 3.7 and below