### PR TITLE
1230 remove hardcoded software ar 1230

### DIFF
--- a/autoreduce_qp/model/database/access.py
+++ b/autoreduce_qp/model/database/access.py
@@ -100,9 +100,7 @@ def get_software(name: str, version: str) -> Software:
     if not "AUTOREDUCTION_PRODUCTION" in os.environ:
         return Software.objects.get_or_create(name=name, version=version)[0]
     else:
-        if Software.objects.filter(name=name).count() == 0:
-            raise ValueError(f"Software {name} is not supported.")
-        elif Software.objects.filter(name=name, version=version).count() == 0:
+        if Software.objects.filter(name=name, version=version).count() == 0:
             raise ValueError(f"Software {name} version {version} is not supported.")
         return Software.objects.get(name=name, version=version)
 

--- a/autoreduce_qp/model/database/access.py
+++ b/autoreduce_qp/model/database/access.py
@@ -95,11 +95,6 @@ def get_software(name: str, version: str) -> Software:
     Return:
         The Software object from the database
     """
-    #TODO: Hardcoded software
-    if not version:
-        # Hard-code a version if not provided until
-        # https://autoreduce.atlassian.net/browse/AR-1230 is addressed
-        version = "6"
     return Software.objects.get_or_create(name=name, version=version)[0]
 
 

--- a/autoreduce_qp/model/database/access.py
+++ b/autoreduce_qp/model/database/access.py
@@ -96,13 +96,14 @@ def get_software(name: str, version: str) -> Software:
     Return:
         The Software object from the database
     """
-    # If running in production environment, then we don't want to create a new software record
+    # If running in test env, create and delete a test software record
     if not "AUTOREDUCTION_PRODUCTION" in os.environ:
         return Software.objects.get_or_create(name=name, version=version)[0]
     else:
-        # If the matching version isn't in the list of versions, then it is unsupported
-        if version not in Software.objects.filter(name=name).values_list('version', flat=True):
-            raise ValueError("Unsupported software version")
+        if Software.objects.filter(name=name).count() == 0:
+            raise ValueError(f"Software {name} is not supported.")
+        elif Software.objects.filter(name=name, version=version).count() == 0:
+            raise ValueError(f"Software {name} version {version} is not supported.")
         return Software.objects.get(name=name, version=version)
 
 

--- a/autoreduce_qp/model/database/access.py
+++ b/autoreduce_qp/model/database/access.py
@@ -95,6 +95,7 @@ def get_software(name: str, version: str) -> Software:
     Return:
         The Software object from the database
     """
+    #TODO: Hardcoded software
     if not version:
         # Hard-code a version if not provided until
         # https://autoreduce.atlassian.net/browse/AR-1230 is addressed

--- a/autoreduce_qp/model/database/records.py
+++ b/autoreduce_qp/model/database/records.py
@@ -184,7 +184,7 @@ def create_reduction_run_record(experiment: Experiment, instrument: Instrument, 
                                                 reduction_host=socket.getfqdn(),
                                                 batch_run=batch_run,
                                                 script=script,
-                                                software=software.id,
+                                                software=software,
                                                 arguments=arguments)
     _make_run_numbers(reduction_run, message.run_number)
     _make_data_locations(reduction_run, message.data)

--- a/autoreduce_qp/model/database/records.py
+++ b/autoreduce_qp/model/database/records.py
@@ -17,7 +17,7 @@ import requests
 from requests.exceptions import ConnectionError
 
 from autoreduce_db.reduction_viewer.models import (DataLocation, Experiment, Instrument, ReductionArguments,
-                                                   ReductionScript, RunNumber, ReductionRun, Status)
+                                                   ReductionScript, RunNumber, ReductionRun, Status, Software)
 from autoreduce_qp.queue_processor.reduction.service import ReductionScript as ReductionScriptFile
 from autoreduce_qp.queue_processor.variable_utils import VariableUtils
 
@@ -161,7 +161,7 @@ def _make_script_and_arguments(experiment: Experiment, instrument: Instrument, m
 
 
 def create_reduction_run_record(experiment: Experiment, instrument: Instrument, message, run_version: int,
-                                status: Status):
+                                status: Status, software: Software):
     """
     Create an ORM record for the given reduction run and return this record
     without saving it to the DB.
@@ -184,6 +184,7 @@ def create_reduction_run_record(experiment: Experiment, instrument: Instrument, 
                                                 reduction_host=socket.getfqdn(),
                                                 batch_run=batch_run,
                                                 script=script,
+                                                software=software.id,
                                                 arguments=arguments)
     _make_run_numbers(reduction_run, message.run_number)
     _make_data_locations(reduction_run, message.data)

--- a/autoreduce_qp/model/database/tests/test_access.py
+++ b/autoreduce_qp/model/database/tests/test_access.py
@@ -105,7 +105,7 @@ class TestAccess(TestCase):
     def test_get_supported_software_prod(self):
         """
         Test: The correct Software record is returned
-        When: get_software is called with values that match a database record
+        When: get_software is called with values that match a database record (production environment)
         """
         software = Software.objects.create(name="Mantid", version="6.2.0")
         actual = access.get_software('Mantid', '6.2.0')
@@ -119,7 +119,7 @@ class TestAccess(TestCase):
     def test_get_unsupported_software_prod(self):
         """
         Test: The correct Software record is returned
-        When: get_software is called with values that match a database record
+        When: get_software is called with values that do not match a database record (production environment)
         """
         self.assertRaises(ValueError, access.get_software, 'test software', '6.2.0')
 
@@ -127,7 +127,7 @@ class TestAccess(TestCase):
     def test_get_unsupported_software_version_prod(self):
         """
         Test: The correct Software record is returned
-        When: get_software is called with values that match a database record
+        When: get_software is called with values that do not match a database record (production environment)
         """
         self.assertRaises(ValueError, access.get_software, 'Mantid', '4.0')
 

--- a/autoreduce_qp/model/database/tests/test_access.py
+++ b/autoreduce_qp/model/database/tests/test_access.py
@@ -9,7 +9,7 @@
 Unit tests to exercise the code responsible for common database access methods
 """
 import os
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 from django.test import TestCase
 
 from autoreduce_db.reduction_viewer.models import Experiment, Instrument, Software

--- a/autoreduce_qp/model/database/tests/test_access.py
+++ b/autoreduce_qp/model/database/tests/test_access.py
@@ -11,7 +11,7 @@ Unit tests to exercise the code responsible for common database access methods
 from unittest.mock import Mock
 from django.test import TestCase
 
-from autoreduce_db.reduction_viewer.models import Experiment, Instrument
+from autoreduce_db.reduction_viewer.models import Experiment, Instrument, Software
 from autoreduce_qp.model.database import access
 from autoreduce_qp.model.database.access import get_all_instrument_names, is_instrument_flat_output
 from autoreduce_qp.model.database.records import create_reduction_run_record
@@ -108,11 +108,12 @@ class TestAccess(TestCase):
 
         experiment, _ = Experiment.objects.get_or_create(reference_number=1231231)
         instrument, _ = Instrument.objects.get_or_create(name="ARMI", is_active=1, is_paused=0)
+        software, _ = Software.objects.get_or_create(name="Mantid", version="6.2.0")
         status = access.get_status("q")
         msg = make_test_message(instrument.name)
 
         for i in range(3):
-            create_reduction_run_record(experiment, instrument, msg, i, status)
+            create_reduction_run_record(experiment, instrument, msg, i, status, software)
 
         assert access.find_highest_run_version(experiment, msg.run_number) == 3
 
@@ -125,13 +126,14 @@ class TestAccess(TestCase):
 
         experiment, _ = Experiment.objects.get_or_create(reference_number=1231231)
         instrument, _ = Instrument.objects.get_or_create(name="ARMI", is_active=1, is_paused=0)
+        software, _ = Software.objects.get_or_create(name="Mantid", version="6.2.0")
         msg = make_test_message(instrument.name)
 
         msg.run_number = [1234567, 1234568, 1234569]
         status = access.get_status("q")
 
         for i in range(3):
-            create_reduction_run_record(experiment, instrument, msg, i, status)
+            create_reduction_run_record(experiment, instrument, msg, i, status, software)
 
         assert access.find_highest_run_version(experiment, msg.run_number) == 3
 
@@ -148,13 +150,14 @@ class TestAccess(TestCase):
 
         experiment, _ = Experiment.objects.get_or_create(reference_number=1231231)
         instrument, _ = Instrument.objects.get_or_create(name="ARMI", is_active=1, is_paused=0)
+        software, _ = Software.objects.get_or_create(name="Mantid", version="6.2.0")
         msg = make_test_message(instrument.name)
 
         msg.run_number = [1234567, 1234570, 1234572]
         status = access.get_status("q")
 
         for i in range(3):
-            create_reduction_run_record(experiment, instrument, msg, i, status)
+            create_reduction_run_record(experiment, instrument, msg, i, status, software)
 
         assert access.find_highest_run_version(experiment, msg.run_number) == 3
 

--- a/autoreduce_qp/model/database/tests/test_access.py
+++ b/autoreduce_qp/model/database/tests/test_access.py
@@ -9,7 +9,7 @@
 Unit tests to exercise the code responsible for common database access methods
 """
 import os
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 from django.test import TestCase
 
 from autoreduce_db.reduction_viewer.models import Experiment, Instrument, Software
@@ -90,19 +90,41 @@ class TestAccess(TestCase):
         self.assertIsInstance(actual, Experiment)
         actual.delete()
 
-    def test_get_software(self):
+    def test_get_supported_software(self):
         """
         Test: The correct Software record is returned
         When: get_software is called with values that match a database record
         """
-        actual = access.get_software('Mantid', '4.0')
+        actual = access.get_software('Mantid', '6.2.0')
         self.assertIsNotNone(actual)
         self.assertEqual('Mantid', actual.name)
-        self.assertEqual('4.0', actual.version)
+        self.assertEqual('6.2.0', actual.version)
         actual.delete()
 
     @patch.dict(os.environ, {"AUTOREDUCTION_PRODUCTION": "1"})
-    def test_get_unsupported_software(self):
+    def test_get_supported_software_prod(self):
+        """
+        Test: The correct Software record is returned
+        When: get_software is called with values that match a database record
+        """
+        software = Software.objects.create(name="Mantid", version="6.2.0")
+        actual = access.get_software('Mantid', '6.2.0')
+        self.assertIsNotNone(actual)
+        self.assertEqual('Mantid', actual.name)
+        self.assertEqual('6.2.0', actual.version)
+        actual.delete()
+        software.delete()
+
+    @patch.dict(os.environ, {"AUTOREDUCTION_PRODUCTION": "1"})
+    def test_get_unsupported_software_prod(self):
+        """
+        Test: The correct Software record is returned
+        When: get_software is called with values that match a database record
+        """
+        self.assertRaises(ValueError, access.get_software, 'test software', '6.2.0')
+
+    @patch.dict(os.environ, {"AUTOREDUCTION_PRODUCTION": "1"})
+    def test_get_unsupported_software_version_prod(self):
         """
         Test: The correct Software record is returned
         When: get_software is called with values that match a database record

--- a/autoreduce_qp/model/database/tests/test_access.py
+++ b/autoreduce_qp/model/database/tests/test_access.py
@@ -8,7 +8,8 @@
 """
 Unit tests to exercise the code responsible for common database access methods
 """
-from unittest.mock import Mock
+import os
+from unittest.mock import Mock, patch
 from django.test import TestCase
 
 from autoreduce_db.reduction_viewer.models import Experiment, Instrument, Software
@@ -99,6 +100,14 @@ class TestAccess(TestCase):
         self.assertEqual('Mantid', actual.name)
         self.assertEqual('4.0', actual.version)
         actual.delete()
+
+    @patch.dict(os.environ, {"AUTOREDUCTION_PRODUCTION": "1"})
+    def test_get_unsupported_software(self):
+        """
+        Test: The correct Software record is returned
+        When: get_software is called with values that match a database record
+        """
+        self.assertRaises(ValueError, access.get_software, 'Mantid', '4.0')
 
     def test_find_highest_run_version_single_run_number(self):
         """

--- a/autoreduce_qp/model/database/tests/test_records.py
+++ b/autoreduce_qp/model/database/tests/test_records.py
@@ -52,13 +52,15 @@ class TestDatabaseRecords(TestCase):
         mock_arguments = mock.NonCallableMock()
         mock_status = mock.NonCallableMock()
         mock_message = mock.NonCallableMagicMock()
+        mock_software = mock.NonCallableMagicMock()
 
         _make_script_and_arguments.return_value = mock_script, mock_arguments, mock_message
         returned_run, returned_msg = records.create_reduction_run_record(experiment=mock_experiment,
                                                                          instrument=mock_inst,
                                                                          message=mock_msg,
                                                                          run_version=mock_run_version,
-                                                                         status=mock_status)
+                                                                         status=mock_status,
+                                                                         software=mock_software)
         self.assertEqual(ReductionRun.objects.create.return_value, returned_run)
         self.assertEqual(mock_msg, returned_msg)
 

--- a/autoreduce_qp/model/database/tests/test_records.py
+++ b/autoreduce_qp/model/database/tests/test_records.py
@@ -75,6 +75,7 @@ class TestDatabaseRecords(TestCase):
             status_id=mock_status.id,
             started_by=mock_msg.started_by,
             run_title=mock_msg.run_title,
+            software=mock_software,
             # Hardcoded below
             run_description=mock.ANY,
             hidden_in_failviewer=mock.ANY,

--- a/autoreduce_qp/queue_processor/handle_message.py
+++ b/autoreduce_qp/queue_processor/handle_message.py
@@ -18,7 +18,8 @@ from typing import Optional
 from django.db import transaction
 from django.utils import timezone
 
-from autoreduce_db.reduction_viewer.models import Experiment, Instrument, ReductionLocation, ReductionRun, Status, Software
+from autoreduce_db.reduction_viewer.models import (Experiment, Instrument, ReductionLocation, ReductionRun, Status,
+                                                   Software)
 from autoreduce_utils.message.message import Message
 from autoreduce_qp.model.database import access as db_access
 from autoreduce_qp.model.database import records

--- a/autoreduce_qp/queue_processor/reduction/process_manager.py
+++ b/autoreduce_qp/queue_processor/reduction/process_manager.py
@@ -15,15 +15,19 @@ from docker.errors import APIError, ImageNotFound, ContainerError
 
 from autoreduce_utils.settings import ARCHIVE_ROOT, AUTOREDUCE_HOME_ROOT, PROJECT_DEV_ROOT
 from autoreduce_utils.message.message import Message
+from autoreduce_db.reduction_viewer.models import Software
+
+from autoreduce_qp.queue_processor.reduction.utilities import get_correct_image
 
 logger = logging.getLogger(__file__)
 
 
 class ReductionProcessManager:
 
-    def __init__(self, message: Message, run_name: str) -> None:
+    def __init__(self, message: Message, run_name: str, software: Software) -> None:
         self.message: Message = message
         self.run_name = run_name
+        self.software = software
 
     def run(self) -> Message:
         """Run the reduction subprocess."""
@@ -46,6 +50,8 @@ class ReductionProcessManager:
                 # https://docs.docker.com/engine/reference/commandline/cli/#environment-variables
                 client = docker.from_env()
 
+                image = get_correct_image(client, self.software)
+
                 # Pull all tags of runner-mantid as a list
                 # Could be used to populate a dropdown menu of images
                 runner_mantid = client.images.pull('ghcr.io/autoreduction/runner-mantid:6.2.0')
@@ -65,7 +71,7 @@ class ReductionProcessManager:
                     Path(f'{AUTOREDUCE_HOME_ROOT}/logs/autoreduce.log').chmod(0o777)
 
                 container = client.containers.run(
-                    image=runner_mantid,
+                    image=image,
                     command=args,
                     volumes={
                         AUTOREDUCE_HOME_ROOT: {

--- a/autoreduce_qp/queue_processor/reduction/process_manager.py
+++ b/autoreduce_qp/queue_processor/reduction/process_manager.py
@@ -52,10 +52,6 @@ class ReductionProcessManager:
 
                 image = get_correct_image(client, self.software)
 
-                # Pull all tags of runner-mantid as a list
-                # Could be used to populate a dropdown menu of images
-                runner_mantid = client.images.pull('ghcr.io/autoreduction/runner-mantid:6.2.0')
-
                 if "AUTOREDUCTION_PRODUCTION" in os.environ:
                     reduced_data = Path('/instrument')
                 else:

--- a/autoreduce_qp/queue_processor/reduction/runner.py
+++ b/autoreduce_qp/queue_processor/reduction/runner.py
@@ -45,7 +45,6 @@ class ReductionRunner:
 
     def _do_reduce(self):
         """Actually do the reduction job."""
-        self.message.software = self._get_mantid_version()
         if self.message.description is not None:
             logger.info("DESCRIPTION: %s", self.message.description)
 

--- a/autoreduce_qp/queue_processor/reduction/tests/common.py
+++ b/autoreduce_qp/queue_processor/reduction/tests/common.py
@@ -25,6 +25,10 @@ def add_data_and_message():
             }
         },
         'description': 'This is a test',
+        'software': {
+            "name": "Mantid",
+            "version": "6.2.0",
+        },
     }
 
     message = Message()

--- a/autoreduce_qp/queue_processor/reduction/tests/test_process_manager.py
+++ b/autoreduce_qp/queue_processor/reduction/tests/test_process_manager.py
@@ -22,7 +22,7 @@ class TestReductionProcessManager(unittest.TestCase):
         self.expected_data, self.expected_message = expected_return_data_and_message()
         self.bad_data, self.bad_message = add_bad_data_and_message()
         self.run_name = "Test run name"
-        self.software = Software.objects.get_or_create(name="Mantid", version="6.2.0")
+        self.software = Software(name="Mantid", version="3.0.0")
 
     def test_init(self):
         """Test that the constructor is doing what's expected"""

--- a/autoreduce_qp/queue_processor/reduction/tests/test_process_manager.py
+++ b/autoreduce_qp/queue_processor/reduction/tests/test_process_manager.py
@@ -9,10 +9,11 @@ import unittest
 from unittest.mock import Mock, patch
 from docker.errors import APIError, ImageNotFound
 
+from autoreduce_db.reduction_viewer.models import Software
+
 from autoreduce_qp.queue_processor.reduction.process_manager import ReductionProcessManager
 from autoreduce_qp.queue_processor.reduction.tests.common import (add_bad_data_and_message, add_data_and_message,
                                                                   expected_return_data_and_message)
-from autoreduce_db.reduction_viewer.models import Software
 
 
 class TestReductionProcessManager(unittest.TestCase):

--- a/autoreduce_qp/queue_processor/reduction/tests/test_process_manager.py
+++ b/autoreduce_qp/queue_processor/reduction/tests/test_process_manager.py
@@ -22,7 +22,7 @@ class TestReductionProcessManager(unittest.TestCase):
         self.expected_data, self.expected_message = expected_return_data_and_message()
         self.bad_data, self.bad_message = add_bad_data_and_message()
         self.run_name = "Test run name"
-        self.software = Software(name="Mantid", version="3.0.0")
+        self.software = Software(name="Mantid", version="6.2.0")
 
     def test_init(self):
         """Test that the constructor is doing what's expected"""

--- a/autoreduce_qp/queue_processor/reduction/tests/test_runner.py
+++ b/autoreduce_qp/queue_processor/reduction/tests/test_runner.py
@@ -133,7 +133,6 @@ class TestReductionRunner(unittest.TestCase):
         runner.reduce()
         mock_logger_info.assert_called_once()
         assert mock_logger_info.call_args[0][1] == "testdescription"
-        _get_mantid_version.assert_called_once()
         assert runner.message.message, ('Error encountered when trying to access the datafile'
                                         ' /isis/NDXTESTINSTRUMENT/Instrument/data/cycle_21_1/data.nxs')
 
@@ -181,7 +180,6 @@ class TestReductionRunner(unittest.TestCase):
             runner.reduce()
 
         reduce.assert_called_once()
-        _get_mantid_version.assert_called_once()
         assert str(reduce.call_args[0][2][0].path) == tmpfile.name
         assert runner.message.reduction_data is None
         assert runner.message.software == "5.1.0"
@@ -201,7 +199,6 @@ class TestReductionRunner(unittest.TestCase):
             runner.reduce()
 
         reduce.assert_called_once()
-        _get_mantid_version.assert_called_once()
         assert str(reduce.call_args[0][2][0].path) == tmpfile.name
         assert runner.message.reduction_data is None
         assert runner.message.software == "5.1.0"
@@ -224,7 +221,6 @@ class TestReductionRunner(unittest.TestCase):
             runner.reduce()
 
         reduce.assert_called_once()
-        _get_mantid_version.assert_called_once()
         assert str(reduce.call_args[0][2][0].path) == tmpfile.name
         assert runner.message.reduction_data is not None
         assert runner.message.reduction_log is not None
@@ -254,6 +250,5 @@ class TestReductionRunner(unittest.TestCase):
             runner.reduce()
 
         reduce.assert_called_once()
-        _get_mantid_version.assert_called_once()
         assert str(reduce.call_args[0][2][0].path) == tmpfile.name
         assert runner.message.flat_output is True

--- a/autoreduce_qp/queue_processor/reduction/tests/test_runner.py
+++ b/autoreduce_qp/queue_processor/reduction/tests/test_runner.py
@@ -182,7 +182,10 @@ class TestReductionRunner(unittest.TestCase):
         reduce.assert_called_once()
         assert str(reduce.call_args[0][2][0].path) == tmpfile.name
         assert runner.message.reduction_data is None
-        assert runner.message.software == "5.1.0"
+        assert runner.message.software == {
+            "name": "Mantid",
+            "version": "6.2.0",
+        }
         assert "Error encountered when running the reduction script" in runner.message.message
 
     @patch(f'{DIR}.runner.ReductionRunner._get_mantid_version', return_value="5.1.0")
@@ -201,7 +204,10 @@ class TestReductionRunner(unittest.TestCase):
         reduce.assert_called_once()
         assert str(reduce.call_args[0][2][0].path) == tmpfile.name
         assert runner.message.reduction_data is None
-        assert runner.message.software == "5.1.0"
+        assert runner.message.software == {
+            "name": "Mantid",
+            "version": "6.2.0",
+        }
         assert "REDUCTION Error:" in runner.message.message
 
     @parameterized.expand([["str"], ["list"]])
@@ -225,7 +231,10 @@ class TestReductionRunner(unittest.TestCase):
         assert runner.message.reduction_data is not None
         assert runner.message.reduction_log is not None
         assert runner.message.message is None
-        assert runner.message.software == "5.1.0"
+        assert runner.message.software == {
+            "name": "Mantid",
+            "version": "6.2.0",
+        }
 
     @staticmethod
     def test_get_mantid_version():

--- a/autoreduce_qp/queue_processor/reduction/tests/test_utilities.py
+++ b/autoreduce_qp/queue_processor/reduction/tests/test_utilities.py
@@ -10,14 +10,13 @@ import contextlib
 import io
 import unittest
 from pathlib import Path
-import docker
 
 from unittest.mock import MagicMock, patch
 from parameterized import parameterized
+import docker
 
-from autoreduce_db.reduction_viewer.models import Software
-
-from autoreduce_qp.queue_processor.reduction.utilities import get_correct_image, windows_to_linux_path, channels_redirected
+from autoreduce_qp.queue_processor.reduction.utilities import (get_correct_image, windows_to_linux_path,
+                                                               channels_redirected)
 
 
 class TestReductionRunnerHelpers(unittest.TestCase):

--- a/autoreduce_qp/queue_processor/reduction/utilities.py
+++ b/autoreduce_qp/queue_processor/reduction/utilities.py
@@ -97,4 +97,4 @@ def get_correct_image(client, software: Software):
         return client.images.pull(image_name.lower())
     # If the matching version isn't in the list of versions, then it is unsupported
     except APIError as exc:
-        raise exc(f"Unsupported software: {software.name}")
+        raise exc

--- a/autoreduce_qp/queue_processor/reduction/utilities.py
+++ b/autoreduce_qp/queue_processor/reduction/utilities.py
@@ -12,9 +12,7 @@ import sys
 from contextlib import contextmanager
 from typing import List, Union
 from autoreduce_db.reduction_viewer.models import Software
-from docker.errors import ImageNotFound, APIError
-
-IMAGES_SOFTWARE = [{'name': 'Mantid', 'versions': ['6', '6.1.0', '6.2.0']}]
+from docker.errors import APIError
 
 
 @contextmanager

--- a/autoreduce_qp/queue_processor/reduction/utilities.py
+++ b/autoreduce_qp/queue_processor/reduction/utilities.py
@@ -12,7 +12,7 @@ import sys
 from contextlib import contextmanager
 from typing import List, Union
 from autoreduce_db.reduction_viewer.models import Software
-from docker.errors import ImageNotFound
+from docker.errors import ImageNotFound, APIError
 
 IMAGES_SOFTWARE = [{'name': 'Mantid', 'versions': ['6', '6.1.0', '6.2.0']}]
 
@@ -98,8 +98,5 @@ def get_correct_image(client, software: Software):
         image_name = f"ghcr.io/autoreduction/runner-{software.name}:{software.version}"
         return client.images.pull(image_name.lower())
     # If the matching version isn't in the list of versions, then it is unsupported
-    except ValueError:
-        raise ValueError(f"Unsupported software: {software.name}")
-    # If the specified image does not exist.
-    except ImageNotFound as exc:
-        raise exc
+    except APIError as exc:
+        raise exc(f"Unsupported software: {software.name}")

--- a/autoreduce_qp/queue_processor/reduction/utilities.py
+++ b/autoreduce_qp/queue_processor/reduction/utilities.py
@@ -93,9 +93,9 @@ def get_correct_image(client, software: Software):
     """
 
     try:
-        # All 'runner' containers are named 'runner-<software_name>-<version>'
-        # e.g. 'runner-Mantid-6.2.0'
-        return client.containers.get(f"runner-{str(software)}")
+        # All 'runner' images are named 'runner-<software_name>-<version>'
+        # e.g. 'runner-Mantid:6.2.0'
+        return client.images.pull(f"ghcr.io/autoreduction/runner-{software.name}:{software.version}")
     # If the matching version isn't in the list of versions, then it is unsupported
     except ValueError:
         raise ValueError(f"Unsupported software: {software.name}")

--- a/autoreduce_qp/queue_processor/reduction/utilities.py
+++ b/autoreduce_qp/queue_processor/reduction/utilities.py
@@ -95,7 +95,8 @@ def get_correct_image(client, software: Software):
     try:
         # All 'runner' images are named 'runner-<software_name>-<version>'
         # e.g. 'runner-Mantid:6.2.0'
-        return client.images.pull(f"ghcr.io/autoreduction/runner-{software.name}:{software.version}")
+        image_name = f"ghcr.io/autoreduction/runner-{software.name}:{software.version}"
+        return client.images.pull(image_name.lower())
     # If the matching version isn't in the list of versions, then it is unsupported
     except ValueError:
         raise ValueError(f"Unsupported software: {software.name}")

--- a/autoreduce_qp/queue_processor/reduction/utilities.py
+++ b/autoreduce_qp/queue_processor/reduction/utilities.py
@@ -11,6 +11,10 @@ Post-Process Admin Utilities
 import sys
 from contextlib import contextmanager
 from typing import List, Union
+from autoreduce_db.reduction_viewer.models import Software
+from docker.errors import ImageNotFound
+
+IMAGES_SOFTWARE = [{'name': 'Mantid', 'versions': ['6', '6.1.0', '6.2.0']}]
 
 
 @contextmanager
@@ -79,3 +83,22 @@ def windows_to_linux_path(paths: Union[str, List[str]], temp_root_directory) -> 
                                     '/isis/').replace('\\\\autoreduce\\data\\',
                                                       temp_root_directory + '/data/').replace('\\', '/')
         return paths
+
+
+def get_correct_image(client, software: Software):
+    """ Fetch correct image based on the software and version
+    :param client: Docker client
+    :param software: (class) Software to be used
+    :return: (Image) Image that contains the correct version of the software
+    """
+
+    try:
+        # All 'runner' containers are named 'runner-<software_name>-<version>'
+        # e.g. 'runner-Mantid-6.2.0'
+        return client.containers.get(f"runner-{str(software)}")
+    # If the matching version isn't in the list of versions, then it is unsupported
+    except ValueError:
+        raise ValueError(f"Unsupported software: {software.name}")
+    # If the specified image does not exist.
+    except ImageNotFound as exc:
+        raise exc

--- a/autoreduce_qp/queue_processor/tests/test_handle_message.py
+++ b/autoreduce_qp/queue_processor/tests/test_handle_message.py
@@ -336,13 +336,13 @@ class TestHandleMessage(TestCase):
         """Test creating a run record when the rb number is invalid."""
         with DefaultDataArchive(self.instrument_name):
             self.msg.rb_number = "INVALID RB NUMBER CALIBRATION RUN PERHAPS"
-            reduction_run, _, _ = self.handler.create_run_records(self.msg)
+            reduction_run, _, _, _ = self.handler.create_run_records(self.msg)
             assert reduction_run.experiment.reference_number == 0
 
     def test_create_run_records_valid_rb_number(self):
         """Test creating a run record when the rb number is invalid."""
         with DefaultDataArchive(self.instrument_name):
-            reduction_run, _, _ = self.handler.create_run_records(self.msg)
+            reduction_run, _, _, _ = self.handler.create_run_records(self.msg)
             assert reduction_run.experiment.reference_number == self.msg.rb_number
 
     @patch("autoreduce_qp.queue_processor.handle_message.records.VariableUtils.get_default_variables")

--- a/autoreduce_qp/queue_processor/tests/test_handle_message.py
+++ b/autoreduce_qp/queue_processor/tests/test_handle_message.py
@@ -166,7 +166,7 @@ class TestHandleMessage(TestCase):
         self.reduction_run.run_numbers.create(run_number=7654322)
 
         self.handler.do_reduction(self.reduction_run, self.msg, self.software)
-        rpm.assert_called_once_with(self.msg, "batch-7654321-7654322")
+        rpm.assert_called_once_with(self.msg, "batch-7654321-7654322", self.software)
         assert self.reduction_run.status == Status.get_completed()
         assert self.reduction_run.started is not None
         assert self.reduction_run.finished is not None

--- a/autoreduce_qp/queue_processor/tests/test_handle_message.py
+++ b/autoreduce_qp/queue_processor/tests/test_handle_message.py
@@ -16,7 +16,7 @@ from django.db.utils import IntegrityError
 from django.test import TestCase
 from parameterized import parameterized
 
-from autoreduce_db.reduction_viewer.models import (Experiment, Instrument, Status)
+from autoreduce_db.reduction_viewer.models import (Experiment, Instrument, Status, Software)
 from autoreduce_utils.message.message import Message
 from autoreduce_qp.model.database.records import create_reduction_run_record
 from autoreduce_qp.queue_processor.handle_message import HandleMessage
@@ -36,7 +36,10 @@ def make_test_message(instrument: str) -> Message:
         "reduction_data": "/path/1",
         "started_by": -1,
         "data": "/path",
-        "software": "6.0.0",
+        'software': {
+            "name": "Mantid",
+            "version": "6.2.0",
+        },
         "description": "This is a fake description",
         "instrument": instrument,  # Autoreduction Mock Instrument
         "reduction_script": """def main(input_file, output_dir): print(123)""",
@@ -64,9 +67,10 @@ class TestHandleMessage(TestCase):
 
         self.experiment, _ = Experiment.objects.get_or_create(reference_number=1231231)
         self.instrument, _ = Instrument.objects.get_or_create(name=self.instrument_name, is_active=True)
+        self.software, _ = Software.objects.get_or_create(name="Mantid", version="6.2.0")
         status = Status.get_queued()
         self.reduction_run, self.message = create_reduction_run_record(self.experiment, self.instrument, self.msg, 0,
-                                                                       status)
+                                                                       status, self.software)
 
     @parameterized.expand([
         ["reduction_error", 'e'],
@@ -124,8 +128,8 @@ class TestHandleMessage(TestCase):
         assert self.reduction_run.finished is not None
         assert self.reduction_run.status == Status.get_completed()
         self.mocked_logger.info.assert_called_once()
-        assert self.reduction_run.software.name == "Mantid"
-        assert self.reduction_run.software.version == self.msg.software
+        assert self.reduction_run.software.name == self.msg.software.get("name")
+        assert self.reduction_run.software.version == self.msg.software.get("version")
         assert self.reduction_run.reduction_location.count() == 0
 
     def test_reduction_complete_with_reduction_data(self):
@@ -148,7 +152,7 @@ class TestHandleMessage(TestCase):
         """Test the success path of do_reduction."""
         rpm.return_value.run = self.do_post_started_assertions
 
-        self.handler.do_reduction(self.reduction_run, self.msg)
+        self.handler.do_reduction(self.reduction_run, self.msg, self.software)
         assert self.reduction_run.status == Status.get_completed()
         assert self.reduction_run.started is not None
         assert self.reduction_run.finished is not None
@@ -161,7 +165,7 @@ class TestHandleMessage(TestCase):
         self.reduction_run.batch_run = True
         self.reduction_run.run_numbers.create(run_number=7654322)
 
-        self.handler.do_reduction(self.reduction_run, self.msg)
+        self.handler.do_reduction(self.reduction_run, self.msg, self.software)
         rpm.assert_called_once_with(self.msg, "batch-7654321-7654322")
         assert self.reduction_run.status == Status.get_completed()
         assert self.reduction_run.started is not None
@@ -178,7 +182,7 @@ class TestHandleMessage(TestCase):
         test_special_chars_script = 'print("✈", "’")'
         self.reduction_run.script.text = test_special_chars_script
 
-        self.handler.do_reduction(self.reduction_run, self.msg)
+        self.handler.do_reduction(self.reduction_run, self.msg, self.software)
         assert self.reduction_run.status == Status.get_completed()
         assert self.reduction_run.started is not None
         assert self.reduction_run.finished is not None
@@ -203,7 +207,7 @@ class TestHandleMessage(TestCase):
 
         rpm.return_value.run = self.do_post_started_assertions
 
-        self.handler.do_reduction(self.reduction_run, self.msg)
+        self.handler.do_reduction(self.reduction_run, self.msg, self.software)
         assert self.reduction_run.status == Status.get_error()
         assert self.reduction_run.started is not None
         assert self.reduction_run.finished is not None
@@ -265,7 +269,7 @@ class TestHandleMessage(TestCase):
         """Test that a run where all is OK is reduced."""
         rpm.return_value.run = partial(self.do_post_started_assertions)
 
-        self.handler.send_message_onwards(self.reduction_run, self.msg, self.instrument)
+        self.handler.send_message_onwards(self.reduction_run, self.msg, self.instrument, self.software)
 
         assert self.reduction_run.status == Status.get_completed()
         assert self.instrument.is_active
@@ -275,7 +279,7 @@ class TestHandleMessage(TestCase):
         """Test that a run that fails validation is skipped."""
         self.msg.rb_number = 123
 
-        self.handler.send_message_onwards(self.reduction_run, self.msg, self.instrument)
+        self.handler.send_message_onwards(self.reduction_run, self.msg, self.instrument, self.software)
 
         rpm.return_value.run.assert_not_called()
         assert self.reduction_run.status == Status.get_skipped()
@@ -290,7 +294,7 @@ class TestHandleMessage(TestCase):
 
         self.msg.run_number = random.randint(1000000, 10000000)
         for i in range(5):
-            reduction_run, message, instrument = self.handler.create_run_records(self.msg)
+            reduction_run, message, instrument, software = self.handler.create_run_records(self.msg)
 
             assert reduction_run.run_number == self.msg.run_number
             assert reduction_run.experiment.reference_number == self.msg.rb_number
@@ -303,6 +307,8 @@ class TestHandleMessage(TestCase):
             assert reduction_run.arguments.as_dict() == self.msg.reduction_arguments
             assert reduction_run.data_location.first().file_path == message.data
             assert reduction_run.status == Status.get_queued()
+            assert software.name == self.msg.software["name"]
+            assert software.version == self.msg.software["version"]
 
     def test_data_ready_other_exception_raised_ends_processing(self):
         """Test an exception being raised inside data_ready handler."""

--- a/autoreduce_qp/queue_processor/tests/test_handle_message.py
+++ b/autoreduce_qp/queue_processor/tests/test_handle_message.py
@@ -323,7 +323,8 @@ class TestHandleMessage(TestCase):
         Test that an integrity error inside data_ready marks the reduction as
         errored.
         """
-        self.handler.create_run_records = Mock(return_value=(self.reduction_run, self.msg, self.instrument))
+        self.handler.create_run_records = Mock(return_value=(self.reduction_run, self.msg, self.instrument,
+                                                             self.software))
         self.handler.send_message_onwards = Mock(side_effect=IntegrityError)
         with self.assertRaises(IntegrityError):
             self.handler.data_ready(self.msg)

--- a/autoreduce_qp/systemtests/base_systemtest.py
+++ b/autoreduce_qp/systemtests/base_systemtest.py
@@ -78,7 +78,10 @@ class BaseAutoreduceSystemTest(TransactionTestCase):
                                           run_title=self.run_title,
                                           description="This is a system test",
                                           facility="ISIS",
-                                          software="6.0.0",
+                                          software={
+                                              "name": "Mantid",
+                                              "version": "6.2.0",
+                                          },
                                           started_by=0,
                                           reduction_script=None,
                                           reduction_arguments=None)

--- a/autoreduce_qp/systemtests/base_systemtest.py
+++ b/autoreduce_qp/systemtests/base_systemtest.py
@@ -66,6 +66,10 @@ class BaseAutoreduceSystemTest(TransactionTestCase):
         self.rb_number = 1234567
         self.run_number = 101
         self.run_title = "test title"
+        self.software = {
+            "name": "Mantid",
+            "version": "6.2.0",
+        }
 
         # Create test archive and add data
         self.data_archive = DataArchive([self.instrument], 19, 19)
@@ -78,22 +82,20 @@ class BaseAutoreduceSystemTest(TransactionTestCase):
                                           run_title=self.run_title,
                                           description="This is a system test",
                                           facility="ISIS",
-                                          software={
-                                              "name": "Mantid",
-                                              "version": "6.2.0",
-                                          },
+                                          software=self.software,
                                           started_by=0,
                                           reduction_script=None,
                                           reduction_arguments=None)
 
-        expected_mantid_py = f"{MANTID_PATH}/mantid.py"
-        if not os.path.exists(expected_mantid_py):
-            os.makedirs(MANTID_PATH)
-            with open(expected_mantid_py, mode="w", encoding="utf-8") as self.test_mantid_py:
-                self.test_mantid_py.write(FAKE_MANTID)
-        else:
-            # Mantid is installed, don't create or delete (in tearDown) anything
-            self.test_mantid_py = None
+        if self.software.get("name") == "Mantid":
+            expected_mantid_py = f"{MANTID_PATH}/mantid.py"
+            if not os.path.exists(expected_mantid_py):
+                os.makedirs(MANTID_PATH)
+                with open(expected_mantid_py, mode="w", encoding="utf-8") as self.test_mantid_py:
+                    self.test_mantid_py.write(FAKE_MANTID)
+            else:
+                # Mantid is installed, don't create or delete (in tearDown) anything
+                self.test_mantid_py = None
 
     def tearDown(self):
         """ Disconnect from services, stop external services and delete data archive """


### PR DESCRIPTION
### Summary of work
Fix `message.software` not being utilised properly as it is hardcoded to Mantid in multiple places. (AR-1230)
Lays groundwork for Supporting multiple reduction softwares (AR-1324)

- Makes 'Software' var in Message a dict {name: "", version:""}
- String of Software will be used to fetch the correct image to run the reduction with (Currenly only runner-mantid:6.2.0 is a valid image)

