### PR TITLE
1056 use message reduction script ar 1056

### DIFF
--- a/autoreduce_qp/queue_processor/reduction/runner.py
+++ b/autoreduce_qp/queue_processor/reduction/runner.py
@@ -11,6 +11,7 @@ import io
 import logging
 import os
 import sys
+import tempfile
 import traceback
 
 from autoreduce_utils.message.message import Message
@@ -37,6 +38,7 @@ class ReductionRunner:
         self.run_number = message.run_number
         self.run_version = message.run_version
         self.reduction_arguments = message.reduction_arguments
+        self.reduction_script = message.reduction_script
 
     def reduce(self):
         """Start the reduction job."""
@@ -61,11 +63,13 @@ class ReductionRunner:
             self.message.reduction_log = f"Exception: {err}"
             return  # stops the reduction and allows the parent to read the outcome in the message
 
-        # Attempt to read the reduction script. This does not currently respect
-        # any script passed in the message https://autoreduce.atlassian.net/browse/AR-1056
+        # Attempt to read the reduction script
         try:
-            reduction_script = ReductionScript(self.instrument)
-            reduction_script_path = reduction_script.script_path
+            with tempfile.NamedTemporaryFile(mode='w', encoding='utf-8') as fp:
+                fp.write(self.reduction_script)
+                fp.seek(0)
+                reduction_script = ReductionScript(self.instrument, fp.name)
+                reduction_script_path = reduction_script.script_path
         except Exception as err:
             self.message.message = "Error encountered when trying to read the reduction script"
             self.message.reduction_log = f"Exception: {err}"

--- a/autoreduce_qp/queue_processor/reduction/runner.py
+++ b/autoreduce_qp/queue_processor/reduction/runner.py
@@ -65,10 +65,10 @@ class ReductionRunner:
 
         # Attempt to read the reduction script
         try:
-            with tempfile.NamedTemporaryFile(mode='w', encoding='utf-8') as fp:
-                fp.write(self.reduction_script)
-                fp.seek(0)
-                reduction_script = ReductionScript(self.instrument, fp.name)
+            with tempfile.NamedTemporaryFile(mode='w', encoding='utf-8') as temp_script:
+                temp_script.write(self.reduction_script)
+                temp_script.seek(0)
+                reduction_script = ReductionScript(self.instrument, temp_script.name)
                 reduction_script_path = reduction_script.script_path
         except Exception as err:
             self.message.message = "Error encountered when trying to read the reduction script"

--- a/autoreduce_qp/queue_processor/reduction/service.py
+++ b/autoreduce_qp/queue_processor/reduction/service.py
@@ -123,8 +123,11 @@ class ReductionScript:
     Encapsulates the loading and running of a reduction script
     """
 
-    def __init__(self, instrument, module="reduce.py"):
-        self.script_path: Path = Path(SCRIPTS_DIRECTORY % instrument) / module
+    def __init__(self, instrument, script_path=None, module="reduce.py"):
+        if script_path is None:
+            self.script_path: Path = Path(SCRIPTS_DIRECTORY % instrument) / module
+        else:
+            self.script_path = Path(script_path)
         self.skipped_runs = []
         self.module = None
 

--- a/autoreduce_qp/queue_processor/reduction/tests/test_service.py
+++ b/autoreduce_qp/queue_processor/reduction/tests/test_service.py
@@ -180,6 +180,9 @@ class TestReductionService(unittest.TestCase):
         self.assertEqual([], script.skipped_runs)
         self.assertIsNone(script.module)
 
+        script = ReductionScript(self.instrument, "test_script.py")
+        self.assertEqual(Path("test_script.py"), script.script_path)
+
     def test_reduction_script_run(self):
         """
         Tests: Correct fields set up

--- a/autoreduce_qp/queue_processor/reduction/tests/test_service.py
+++ b/autoreduce_qp/queue_processor/reduction/tests/test_service.py
@@ -56,8 +56,8 @@ class TestReductionService(unittest.TestCase):
         with tempfile.NamedTemporaryFile(mode='w', encoding='utf-8', suffix=".py") as script_file:
             script_file.write(test_string)
             script_file.flush()
-            red_script = ReductionScript(self.instrument)
-            red_script.script_path = Path(script_file.name)
+            script_path = Path(script_file.name)
+            red_script = ReductionScript(self.instrument, script_path=script_path)
             red_script.load()
             yield red_script
 
@@ -180,7 +180,7 @@ class TestReductionService(unittest.TestCase):
         self.assertEqual([], script.skipped_runs)
         self.assertIsNone(script.module)
 
-        script = ReductionScript(self.instrument, "test_script.py")
+        script = ReductionScript(self.instrument, script_path="test_script.py")
         self.assertEqual(Path("test_script.py"), script.script_path)
 
     def test_reduction_script_run(self):
@@ -199,8 +199,8 @@ class TestReductionService(unittest.TestCase):
         """
         Test importing a module that is all OK
         """
-        red_script = ReductionScript(self.instrument)
-        red_script.script_path = Path(os.path.join(os.path.dirname(__file__), "module_to_import.py"))
+        script_path = Path(os.path.join(os.path.dirname(__file__), "module_to_import.py"))
+        red_script = ReductionScript(self.instrument, script_path=script_path)
         module = red_script.load()
 
         assert red_script.exists()
@@ -211,8 +211,8 @@ class TestReductionService(unittest.TestCase):
         """
         Test importing a module that does not exist
         """
-        red_script = ReductionScript(self.instrument)
-        red_script.script_path = Path("some.module.that.does.not.exist")
+        script_path = Path("some.module.that.does.not.exist")
+        red_script = ReductionScript(self.instrument, script_path=script_path)
         with self.assertRaises(ImportError):
             red_script.load()
 
@@ -249,8 +249,8 @@ class TestReductionService(unittest.TestCase):
         """
         Test that replace variables raises if called before the module is loaded
         """
-        red_script = ReductionScript(self.instrument)
-        red_script.script_path = Path("/tmp/file")
+        script_path = Path("/tmp/file")
+        red_script = ReductionScript(self.instrument, script_path=script_path)
         self.assertRaises(RuntimeError, red_script.replace_variables, self.reduction_arguments)
 
     def test_reduction_script_replace_variables(self):

--- a/autoreduce_qp/queue_processor/variable_utils.py
+++ b/autoreduce_qp/queue_processor/variable_utils.py
@@ -46,7 +46,7 @@ class VariableUtils:
                 "advanced_vars": {},
             }
         }
-        reduce_vars = ReductionScript(instrument_name, 'reduce_vars.py')
+        reduce_vars = ReductionScript(instrument_name, script_path=None, module='reduce_vars.py')
 
         try:
             module = reduce_vars.load()

--- a/autoreduce_qp/systemtests/test_end_to_end.py
+++ b/autoreduce_qp/systemtests/test_end_to_end.py
@@ -148,8 +148,8 @@ class TestEndToEnd(BaseAutoreduceSystemTest):
                   no longer matches the value of the first run.
         """
         # Create supporting data structures e.g. Data Archive, Reduce directory
-        file_location = self._setup_data_structures(reduce_script=REDUCE_SCRIPT, vars_script='')
-        self.data_ready_message.data = file_location
+        self._setup_data_structures(reduce_script=REDUCE_SCRIPT, vars_script='')
+        self.data_ready_message.data = EXPECTED_FILE_LOCATION
         result_one = self.send_and_wait_for_result(self.data_ready_message)
 
         assert len(result_one) == 1
@@ -173,8 +173,8 @@ class TestEndToEnd(BaseAutoreduceSystemTest):
                   no longer matches the value of the first run.
         """
         # Create supporting data structures e.g. Data Archive, Reduce directory
-        file_location = self._setup_data_structures(reduce_script=REDUCE_SCRIPT, vars_script=VARS_SCRIPT)
-        self.data_ready_message.data = file_location
+        self._setup_data_structures(reduce_script=REDUCE_SCRIPT, vars_script=VARS_SCRIPT)
+        self.data_ready_message.data = EXPECTED_FILE_LOCATION
         result_one = self.send_and_wait_for_result(self.data_ready_message)
 
         assert len(result_one) == 1
@@ -197,8 +197,8 @@ class TestEndToEnd(BaseAutoreduceSystemTest):
                   no longer matches the value of the first run.
         """
         # Create supporting data structures e.g. Data Archive, Reduce directory
-        file_location = self._setup_data_structures(reduce_script=REDUCE_SCRIPT, vars_script=VARS_SCRIPT)
-        self.data_ready_message.data = file_location
+        self._setup_data_structures(reduce_script=REDUCE_SCRIPT, vars_script=VARS_SCRIPT)
+        self.data_ready_message.data = EXPECTED_FILE_LOCATION
         result_one = self.send_and_wait_for_result(self.data_ready_message)
 
         assert len(result_one) == 1
@@ -221,8 +221,8 @@ class TestEndToEnd(BaseAutoreduceSystemTest):
         has not changed.
         """
         # Create supporting data structures e.g. Data Archive, Reduce directory
-        file_location = self._setup_data_structures(reduce_script=REDUCE_SCRIPT, vars_script=VARS_SCRIPT)
-        self.data_ready_message.data = file_location
+        self._setup_data_structures(reduce_script=REDUCE_SCRIPT, vars_script=VARS_SCRIPT)
+        self.data_ready_message.data = EXPECTED_FILE_LOCATION
         result_one = self.send_and_wait_for_result(self.data_ready_message)
 
         run_with_initial_var = result_one[0]
@@ -239,10 +239,10 @@ class TestEndToEnd(BaseAutoreduceSystemTest):
         changed.
         """
         # Create supporting data structures e.g. Data Archive, Reduce directory
-        file_location = self._setup_data_structures(reduce_script=REDUCE_SCRIPT, vars_script=VARS_SCRIPT)
+        self._setup_data_structures(reduce_script=REDUCE_SCRIPT, vars_script=VARS_SCRIPT)
 
         self.run_number = 101
-        self.data_ready_message.data = file_location
+        self.data_ready_message.data = EXPECTED_FILE_LOCATION
         result_one = self.send_and_wait_for_result(self.data_ready_message)
 
         assert len(result_one) == 1

--- a/autoreduce_qp/systemtests/test_end_to_end.py
+++ b/autoreduce_qp/systemtests/test_end_to_end.py
@@ -265,11 +265,11 @@ class TestEndToEnd(BaseAutoreduceSystemTest):
         """
         Test that the reduction run uses matching pre-configured experiment arguments
         """
-        file_location = self._setup_data_structures(reduce_script=REDUCE_SCRIPT, vars_script=VARS_SCRIPT)
+        self._setup_data_structures(reduce_script=REDUCE_SCRIPT, vars_script=VARS_SCRIPT)
         expected_args = ReductionArguments.objects.create(raw="{}",
                                                           experiment_reference=self.rb_number,
                                                           instrument=self.instrument_obj)
-        self.data_ready_message.data = file_location
+        self.data_ready_message.data = EXPECTED_FILE_LOCATION
         result_one_qs = self.send_and_wait_for_result(self.data_ready_message)
         result_one = result_one_qs[0]
         assert result_one.arguments == expected_args
@@ -278,11 +278,11 @@ class TestEndToEnd(BaseAutoreduceSystemTest):
         """
         Test that the reduction run uses matching pre-configured start run arguments
         """
-        file_location = self._setup_data_structures(reduce_script=REDUCE_SCRIPT, vars_script=VARS_SCRIPT)
+        self._setup_data_structures(reduce_script=REDUCE_SCRIPT, vars_script=VARS_SCRIPT)
         expected_args = ReductionArguments.objects.create(raw="{}",
                                                           start_run=self.run_number,
                                                           instrument=self.instrument_obj)
-        self.data_ready_message.data = file_location
+        self.data_ready_message.data = EXPECTED_FILE_LOCATION
         result_one_qs = self.send_and_wait_for_result(self.data_ready_message)
         result_one = result_one_qs[0]
         assert result_one.arguments == expected_args
@@ -292,12 +292,12 @@ class TestEndToEnd(BaseAutoreduceSystemTest):
         Test that a batch reduction run will ignore matching experiment & run arguments,
         and that batch runs will re-use script and arguments between runs when they are matching.
         """
-        file_location = self._setup_data_structures(reduce_script=REDUCE_SCRIPT, vars_script=VARS_SCRIPT)
+        self._setup_data_structures(reduce_script=REDUCE_SCRIPT, vars_script=VARS_SCRIPT)
         ignored_args = ReductionArguments.objects.create(raw="{}",
                                                          experiment_reference=self.rb_number,
                                                          instrument=self.instrument_obj)
         self.data_ready_message.run_number = [101, 102]
-        self.data_ready_message.data = [file_location, file_location]
+        self.data_ready_message.data = [EXPECTED_FILE_LOCATION, EXPECTED_FILE_LOCATION]
         result_one_qs = self.send_and_wait_for_result(self.data_ready_message)
         result_one = result_one_qs[0]
         # experiment arguments are ignored by batch runs


### PR DESCRIPTION
### Summary of work
Uses the script text from message.reduction_script should be used instead of loading the reduce.py

- write the script text to a tmp file, which can then be loaded by ReductionScript.load

If message.reduction_script is None the reduce.py gets loaded in anyway by the create_reduction_run_record func. (already implemented)
